### PR TITLE
Set corespath

### DIFF
--- a/prepare.ps1
+++ b/prepare.ps1
@@ -103,6 +103,8 @@ Expand-Archive -Path $retroArchBinary -Destination $retroArchPath
 # 
 # 5. Prepare cores
 # 
+$coresPath = $retroArchPath + "cores"
+
 # NES Setup
 $nesCore = $requirementsFolder + "\fceumm_libretro.dll.zip"
 Expand-Archive -Path $nesCore -Destination $coresPath


### PR DESCRIPTION
Since $coresPath wasn't set before using it, the cores weren't being unzipped into the cores dir and the system command paths were incorrect