### PR TITLE
Update prepare.ps1 to work with Github's improved security.

### DIFF
--- a/prepare.ps1
+++ b/prepare.ps1
@@ -1,4 +1,5 @@
 Import-Module BitsTransfer
+[Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls" #Convince Powershell to talk to sites with different versions of TLS
 
 # 
 # 1. Chocolatey installs 


### PR DESCRIPTION
Convince Powershell to talk to sites with different versions of TLS. Feel free to move this line elsewhere, as long as it's before trying to do TLS 1.1 or 1.2 stuff (Like github).